### PR TITLE
Adding updated image for EKS deployments

### DIFF
--- a/Dockerfile.eks
+++ b/Dockerfile.eks
@@ -1,0 +1,19 @@
+FROM ruby:2.3
+
+RUN apt-get update && apt-get install -y curl
+
+ARG KUBECTL_VERSION="1.10.3"
+ARG KUBECTL_BUILD_DATE="2018-07-26"
+
+RUN curl -L https://amazon-eks.s3-us-west-2.amazonaws.com/${KUBECTL_VERSION}/${KUBECTL_BUILD_DATE}/bin/linux/amd64/kubectl > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl
+
+# install aws-iam-authenticator
+RUN curl -L "https://amazon-eks.s3-us-west-2.amazonaws.com/${KUBECTL_VERSION}/${KUBECTL_BUILD_DATE}/bin/linux/amd64/aws-iam-authenticator" > /usr/local/bin/aws-iam-authenticator \
+    && chmod +x /usr/local/bin/aws-iam-authenticator
+
+COPY env_var_helper_client.sh env_var_helper_client.rb ./
+RUN chmod +x env_var_helper_client.sh
+
+ENTRYPOINT ["./env_var_helper_client.sh"]
+

--- a/README.md
+++ b/README.md
@@ -42,3 +42,6 @@ kubectl:
   service: kubectl
   command: kubectl config view
 ```
+
+## Deploying to EKS?
+The same workflow outline above works with EKS, but use the `codeship/eks-kubectl` image, which comes installed with `aws-iam-authenticator` and an AWS-vendored copy of `kubectl`.

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -3,3 +3,9 @@ kubectl:
     image: codeship/kubectl
     dockerfile: Dockerfile
   encrypted_env_file: k8s-env.encrypted
+
+eks-kubectl:
+  build:
+    image: codeship/eks-kubectl
+    dockerfile: Dockerfile.eks
+  encrypted_env_file: k8s-env.encrypted

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -2,9 +2,24 @@
   command: kubectl config view
   service: kubectl
 
+- name: check response to kubectl configi for eks
+  command: kubectl config view
+  service: eks-kubectl
+
+- name: check response to aws-iam-authenticator
+  command: aws-iam-authenticator
+  service: eks-kubectl
+
 - name: push codeship/kubectl
   tag: master
   type: push
   service: kubectl
   image_name: codeship/kubectl
+  encrypted_dockercfg_path: dockercfg.encrypted
+
+- name: push codeship/eks-kubectl
+  tag: master
+  type: push
+  service: eks-kubectl
+  image_name: codeship/eks-kubectl
   encrypted_dockercfg_path: dockercfg.encrypted


### PR DESCRIPTION
Adding another image for use with EKS, which requires the use of aws-iam-authenticator. Splitting it into a different image as we should also use the AWS-vendored kubectl, and I don't want to cause potential conflicts for AKS/GKE or other kube deployments.